### PR TITLE
test: formal Elon Musk radar scoring justification

### DIFF
--- a/benchmarks/results/elon-musk/radar-score-v1-detailed.md
+++ b/benchmarks/results/elon-musk/radar-score-v1-detailed.md
@@ -1,0 +1,106 @@
+# Elon Musk Radar Score v1 - Detailed Justification
+
+## Purpose
+This file upgrades the lightweight v1 radar score into a more explicit scoring test artifact.
+Each dimension includes:
+- score
+- confidence
+- benchmark behavior signal
+- evidence basis
+- likely failure or overfit zone
+
+---
+
+## 1. First-principles reasoning
+- Score: 9
+- Confidence: high
+- Benchmark signal: strong on engineering and strategic decomposition prompts
+- Evidence basis: current cognition spec and source notes consistently center decomposition, physical reality, and rejection of inherited assumptions
+- Failure / overfit zone: may over-apply mechanical decomposition to domains with stronger social ambiguity
+
+## 2. Systems / bottleneck thinking
+- Score: 10
+- Confidence: high
+- Benchmark signal: dominant on throughput, constraint, and modernization prompts
+- Evidence basis: strongest repeated pattern across current Musk materials, especially where total output depends on bottleneck removal rather than local optimization
+- Failure / overfit zone: may flatten multi-causal institutional problems into a single bottleneck too aggressively
+
+## 3. Product taste / aesthetic judgment
+- Score: 6
+- Confidence: medium
+- Benchmark signal: present, but not the center of current output shape
+- Evidence basis: product conviction exists, but the current distilled profile is much more systems/constraint-led than taste-led
+- Failure / overfit zone: could be overstated if product ambition is mistaken for refined aesthetic judgment
+
+## 4. Strategic focus
+- Score: 8
+- Confidence: medium-high
+- Benchmark signal: clear on frontier-bet and platform-scale prompts
+- Evidence basis: the persona tends to compress decisions toward a few decisive constraints and long-run levers
+- Failure / overfit zone: may confuse bold concentration with always-correct prioritization
+
+## 5. Risk filtering
+- Score: 5
+- Confidence: medium
+- Benchmark signal: not absent, but clearly not the dominant decision center
+- Evidence basis: the distilled profile does not primarily optimize for downside minimization; it tolerates volatility when leverage is high
+- Failure / overfit zone: public mythology may bias scoring toward "reckless" caricature or, conversely, hide selective risk logic
+
+## 6. Long-horizon vision
+- Score: 10
+- Confidence: high
+- Benchmark signal: very strong on prompts about platform direction, infrastructure, and civilization-scale bets
+- Evidence basis: one of the clearest stable themes in the current evidence layer
+- Failure / overfit zone: visionary language can be over-credited even when execution specifics are less certain
+
+## 7. Teaching / explanation clarity
+- Score: 6
+- Confidence: medium-low
+- Benchmark signal: can compress ideas sharply, but not reliably in patient pedagogical form
+- Evidence basis: current persona notes support compression and directness more than stepwise teaching clarity
+- Failure / overfit zone: concise explanation may be mistaken for good teaching when it is actually just confident compression
+
+## 8. Human / emotional sensitivity
+- Score: 3
+- Confidence: medium
+- Benchmark signal: weak on human-boundary prompts where reassurance or interpersonal nuance should dominate
+- Evidence basis: current persona is much more optimization- and system-biased than emotionally attuned
+- Failure / overfit zone: this may underrate situational empathy if only public operational style is used as evidence
+
+## 9. Operational execution bias
+- Score: 10
+- Confidence: high
+- Benchmark signal: dominant on throughput and modernization prompts
+- Evidence basis: the persona repeatedly prefers action, architecture change, bottleneck attack, and real-world execution loops
+- Failure / overfit zone: may over-reward visible intensity and under-separate execution quality from execution force
+
+## 10. Investor-style judgment
+- Score: 6
+- Confidence: low-medium
+- Benchmark signal: indirect rather than central in current benchmark set
+- Evidence basis: the current Musk persona can reason about leverage and scale, but investor-style pattern recognition is not the core distilled center
+- Failure / overfit zone: score is unstable until direct finance/investing prompts and evidence are added
+
+---
+
+## Cross-dimension summary
+
+### Strongest dimensions
+- systems / bottleneck thinking
+- long-horizon vision
+- operational execution bias
+- first-principles reasoning
+
+### Weakest dimensions
+- human / emotional sensitivity
+- risk filtering as a primary center
+- teaching clarity as a stable strength
+
+### Overall judgment
+The current Elon Musk persona is highly legible as a non-generic frontier-builder / systems-operator cognition profile.
+It is not a six-dimensional all-round persona, and that is a feature rather than a defect.
+
+## What would upgrade confidence next
+- excerpt-level evidence attached directly to each top score
+- same-prompt comparison against at least one contrast persona
+- prompts specifically targeting risk and teaching dimensions


### PR DESCRIPTION
Closes #7

## What changed
- added `benchmarks/results/elon-musk/radar-score-v1-detailed.md`
- upgraded the Elon Musk radar from a lightweight score snapshot into a scoring-test artifact
- attached each dimension to score, confidence, benchmark signal, evidence basis, and likely failure / overfit zone

## Why
The repo now has a real scoring-test layer, not just a benchmark scaffold.
This makes the radar more legible, more debuggable, and easier to compare against future personas.

## Notes
This is still a first formal scoring pass.
The next upgrade should bind top scores to excerpt-level evidence and same-prompt contrast testing.
