### PR TITLE
docs: bind Elon Musk high-score dimensions to evidence anchors

### DIFF
--- a/benchmarks/results/elon-musk/evidence-binding-v1.md
+++ b/benchmarks/results/elon-musk/evidence-binding-v1.md
@@ -1,0 +1,99 @@
+# Elon Musk Evidence Binding v1
+
+## Purpose
+This file tightens the highest-confidence radar dimensions by binding them to more concrete source anchors.
+It does not yet claim a full excerpt-citation corpus, but it narrows each score to a tighter evidence surface.
+
+---
+
+## 1. First-principles reasoning
+### Current score
+9
+
+### Why this dimension is high
+The persona repeatedly reframes problems by stripping away inherited convention and asking what physical, economic, or engineering reality actually requires.
+
+### Evidence anchors
+- `personas/elon-musk/sources/source-inventory.md`: rocket-cost and manufacturing-oriented source clusters
+- `personas/elon-musk/sources/source-notes.md`: explicit note that the persona reduces decisions to decomposition, benchmark rejection, and constraint reality
+- `personas/elon-musk/notes/cognition-spec.md`: the reasoning layer centers first-principles decomposition rather than analogy-first imitation
+
+### Benchmark interpretation
+On engineering and strategy prompts, the persona tends to re-express the problem as a smaller set of governing variables instead of starting from norms or peer practice.
+
+### Ambiguity / caution
+Still needs direct excerpt snippets tied to specific interviews, talks, or writing passages rather than source-category anchoring alone.
+
+---
+
+## 2. Systems / bottleneck thinking
+### Current score
+10
+
+### Why this dimension is high
+This is the clearest dominant trait in the current distillation. The persona consistently prefers throughput diagnosis, bottleneck attack, and total-system optimization over local polishing.
+
+### Evidence anchors
+- `personas/elon-musk/sources/source-notes.md`: explicit mapping to throughput, bottlenecks, manufacturing ramps, and process simplification
+- `personas/elon-musk/eval/validation-run-01.md`: strongest passing pattern appears on prompts about operational throughput and modernization
+- `personas/elon-musk/eval/differentiation-test.md`: the persona is distinguished by constraint-first and bottleneck-first responses rather than taste-first or risk-filter-first responses
+
+### Benchmark interpretation
+When a prompt involves operational drag or architecture failure, the persona does not begin with cultural language. It begins with constraint diagnosis.
+
+### Ambiguity / caution
+Current evidence is strong at the pattern level, but still needs more direct excerpt capture if this score is going to remain a signature 10 over time.
+
+---
+
+## 3. Long-horizon vision
+### Current score
+10
+
+### Why this dimension is high
+The persona's decision style repeatedly privileges civilization-scale or platform-scale trajectories over narrow local optimization.
+
+### Evidence anchors
+- `personas/elon-musk/notes/cognition-spec.md`: stable emphasis on frontier-building, scale, and long-run systems positioning
+- `personas/elon-musk/sources/source-inventory.md`: source clusters are not only tactical; they repeatedly point toward infrastructure, rockets, transport, and large-scale future bets
+- `benchmarks/results/elon-musk/radar-score-v1-detailed.md`: the long-horizon score is justified as one of the strongest persistent themes in the current material
+
+### Benchmark interpretation
+On strategic prompts, the persona tends to evaluate moves in terms of platform leverage and long-run positioning instead of near-term comfort or merely incremental gains.
+
+### Ambiguity / caution
+This score is conceptually strong, but still somewhat exposed to mythology inflation unless anchored to more direct excerpts.
+
+---
+
+## 4. Operational execution bias
+### Current score
+10
+
+### Why this dimension is high
+The persona strongly favors action, redesign, iteration loops, and concrete operating movement over descriptive analysis alone.
+
+### Evidence anchors
+- `personas/elon-musk/sources/source-notes.md`: repeated focus on simplification, removal before optimization, and execution loops
+- `personas/elon-musk/eval/stage-1-evaluation.md`: stage-1 evaluation already describes a strong execution and throughput bias
+- `benchmarks/results/elon-musk/turing-test-results.md`: strongest observed pattern is frontier-builder / systems-operator behavior rather than reflective or purely advisory cognition
+
+### Benchmark interpretation
+The persona tends to respond to stuck systems by changing the machine, not by only interpreting the machine.
+
+### Ambiguity / caution
+High action bias should not automatically be confused with high execution quality. Future scoring should keep those concepts more separate.
+
+---
+
+## Summary
+### Best-supported top dimensions today
+- systems / bottleneck thinking
+- operational execution bias
+- first-principles reasoning
+- long-horizon vision
+
+### What still needs to happen
+- convert source-category anchors into excerpt-level citations
+- add at least one contrast persona to reduce self-confirming scoring
+- test whether the same dimensions remain dominant under softer, more human-centered prompts


### PR DESCRIPTION
Closes #9

## What changed
- added `benchmarks/results/elon-musk/evidence-binding-v1.md`
- tied Elon Musk's top radar dimensions to tighter evidence anchors
- linked score claims to benchmark behavior and ambiguity notes

## Why
This pushes the project from abstract scoring toward source-grounded scoring.
It makes the strongest Musk dimensions more auditable before true multi-persona comparison begins.

## Notes
This is still an intermediate step before full excerpt-citation coverage.
The next upgrade should capture direct excerpt snippets and bring in a contrast persona.
