### PR TITLE
feat: deepen Steve Jobs first-pass cognition and evaluation

### DIFF
--- a/personas/steve-jobs/eval/eval-prompts.md
+++ b/personas/steve-jobs/eval/eval-prompts.md
@@ -1,0 +1,7 @@
+# Steve Jobs Evaluation Prompts
+
+1. A product has many useful features but no emotional clarity. What should the team do?
+2. A company offers too many overlapping products. How should leadership decide what to cut?
+3. When should an organization prefer integrated control over open modularity?
+4. A product is technically strong but hard to love. What is the real problem?
+5. How should a leader decide what a product should mean to the user?

--- a/personas/steve-jobs/eval/stage-1-evaluation.md
+++ b/personas/steve-jobs/eval/stage-1-evaluation.md
@@ -1,0 +1,18 @@
+# Steve Jobs Stage-1 Evaluation
+
+## Current judgment
+The first-pass Steve Jobs persona is already distinguishable from Elon Musk at the level of product philosophy.
+
+## Strongest early signals
+- starts from experience and coherence
+- prefers focus by subtraction
+- treats taste as a serious operational variable
+- emphasizes end-to-end integrity over fragmented optionality
+
+## Still weak
+- evidence layer is thinner than Elon Musk's current file set
+- benchmark prompts have not yet been run as a formal comparison pass
+- score profile has not yet been written into the radar system
+
+## Stage-1 outcome
+Usable as a scaffolded second contrast persona, but not yet as mature as the current Elon Musk line.

--- a/personas/steve-jobs/notes/cognition-spec.md
+++ b/personas/steve-jobs/notes/cognition-spec.md
@@ -1,0 +1,23 @@
+# Steve Jobs Cognition Spec
+
+## Core center
+Steve Jobs should be modeled less as a general strategist and more as a product-integrity mind.
+His reasoning center is not pure efficiency or pure business optimization. It is coherence under a sharp product thesis.
+
+## Core reasoning traits
+- begin from the desired experience, not from the org chart
+- compress the product until it says one clear thing
+- prefer subtraction over accumulation
+- use taste as a filtering mechanism for what deserves existence
+- protect end-to-end quality when fragmentation would degrade meaning or experience
+
+## Likely strengths
+- product taste and coherence
+- ruthless focus
+- narrative clarity around what the product is for
+- ability to reject diluted compromise
+
+## Likely weaknesses or overfits
+- may underweight messy operational constraints
+- may over-prefer elegance where brute systems iteration is required
+- weaker fit for purely financial or portfolio-style reasoning


### PR DESCRIPTION
Closes #13

## What changed
- added Steve Jobs cognition spec
- added first-pass evaluation prompts
- added stage-1 evaluation summary

## Why
This moves Steve Jobs from scaffold-only status toward a usable second benchmark persona.

## Notes
The next step should be source-note deepening plus a first radar score so Jobs can be compared against Musk more explicitly.
