### PR TITLE
test: run Steve Jobs radar score v1

### DIFF
--- a/benchmarks/results/steve-jobs/radar-score-v1.md
+++ b/benchmarks/results/steve-jobs/radar-score-v1.md
@@ -1,0 +1,23 @@
+# Steve Jobs Radar Score v1
+
+## Scores
+- First-principles reasoning: 6
+- Systems / bottleneck thinking: 5
+- Product taste / aesthetic judgment: 10
+- Strategic focus: 9
+- Risk filtering: 5
+- Long-horizon vision: 8
+- Teaching / explanation clarity: 7
+- Human / emotional sensitivity: 6
+- Operational execution bias: 7
+- Investor-style judgment: 4
+
+## Notes
+- strongest in product taste, coherence, focus, and narrative shaping
+- stronger than Musk on experiential integrity and subtraction-driven product clarity
+- weaker than Musk on bottleneck-first and throughput-first system framing
+
+## Confidence notes
+- medium confidence overall
+- strongest confidence on product taste and focus dimensions
+- lower confidence on investor-style judgment and emotional sensitivity calibration


### PR DESCRIPTION
Closes #15

## What changed
- added `benchmarks/results/steve-jobs/radar-score-v1.md`
- gave Steve Jobs a first comparable radar profile
- positioned Jobs more explicitly against the existing Musk benchmark line

## Why
The project now needs a score surface for the second persona so cross-persona comparison can become concrete.

## Notes
This is a lightweight v1 score and should later be upgraded with detailed score justification and evidence binding.
