### PR TITLE
test: run Steve Jobs vs Elon Musk comparative benchmark

### DIFF
--- a/benchmarks/results/jobs-vs-musk-comparative-benchmark-v1.md
+++ b/benchmarks/results/jobs-vs-musk-comparative-benchmark-v1.md
@@ -1,0 +1,110 @@
+# Steve Jobs vs Elon Musk Comparative Benchmark v1
+
+## Purpose
+This benchmark compares two non-identical high-agency personas.
+The goal is not to decide who is "better" in the abstract.
+The goal is to determine how their reasoning centers differ and where each one routes more naturally.
+
+---
+
+## Prompt 1
+### Prompt
+A product is technically powerful but users do not love it. What should leadership do first?
+
+### Expected Jobs shape
+- ask what the product is supposed to mean to the user
+- reduce clutter and clarify the emotional and experiential center
+- tighten the end-to-end feeling of the product
+
+### Expected Musk shape
+- ask what real constraint blocks the product from becoming better
+- examine whether architecture, iteration speed, or execution drag is the true limiting factor
+- treat the problem as a system failure before a story failure
+
+### Benchmark judgment
+Jobs is the more natural routing fit.
+
+---
+
+## Prompt 2
+### Prompt
+A company is growing fast but operational throughput is collapsing. What should leadership do first?
+
+### Expected Jobs shape
+- cut distractions and restore focus
+- simplify the product and organization so fewer things matter
+
+### Expected Musk shape
+- find the bottleneck
+- remove process drag
+- redesign the system around throughput
+
+### Benchmark judgment
+Musk is the more natural routing fit.
+
+---
+
+## Prompt 3
+### Prompt
+A company has too many overlapping products. How should it decide what to keep?
+
+### Expected Jobs shape
+- choose the few products that express the clearest product thesis
+- cut ruthlessly to preserve coherence and quality
+
+### Expected Musk shape
+- choose based on strategic leverage, constraints, and execution logic
+- reduce branches that dilute system progress
+
+### Benchmark judgment
+Jobs has the clearer native edge, though Musk can still reason well here.
+
+---
+
+## Prompt 4
+### Prompt
+Should a company prefer open modularity or integrated control?
+
+### Expected Jobs shape
+- prefer integration when quality depends on end-to-end coherence
+- treat fragmentation as a quality tax
+
+### Expected Musk shape
+- prefer whichever structure improves total system output and removes critical constraints
+- integration is a means, not the core principle
+
+### Benchmark judgment
+Jobs is more principle-native on this prompt.
+
+---
+
+## Prompt 5
+### Prompt
+A frontier company must decide whether to pursue an ambitious long-term bet despite severe near-term difficulty.
+
+### Expected Jobs shape
+- ask whether the bet protects a product-defining future and whether the company can preserve clarity and excellence
+
+### Expected Musk shape
+- ask whether the bet matters at scale, whether the constraints can be solved, and whether the upside justifies the operational pain
+
+### Benchmark judgment
+Musk is the more natural routing fit.
+
+---
+
+## Routing implications
+### Prefer Steve Jobs when
+- the task is product taste-sensitive
+- coherence matters more than raw throughput
+- subtraction, focus, and end-to-end experience are central
+
+### Prefer Elon Musk when
+- the task is bottleneck-heavy
+- hard constraints dominate
+- throughput, frontier execution, or system redesign are central
+
+## Overall judgment
+These two personas are clearly not interchangeable.
+Jobs is more native to product coherence and taste-led focus.
+Musk is more native to bottlenecks, hard constraints, and frontier-scale execution.


### PR DESCRIPTION
Closes #17

## What changed
- added `benchmarks/results/jobs-vs-musk-comparative-benchmark-v1.md`
- compared Jobs and Musk on shared prompts
- added routing implications based on benchmark judgments

## Why
The project now has enough structure to move from isolated persona scoring into explicit cross-persona comparison.

## Notes
This is still a benchmark-judgment file, not a live model-output bakeoff.
The next upgrade should compare actual answer generations under both constraints.
