### PR TITLE
docs: add persona routing guide from benchmark results

### DIFF
--- a/docs/persona-routing.md
+++ b/docs/persona-routing.md
@@ -1,0 +1,44 @@
+# Persona Routing Guide v1
+
+## Purpose
+This document translates benchmark results into practical routing guidance.
+A persona is not a costume layer. It is a problem-shaping constraint.
+The routing question is therefore: which cognition profile is the most natural fit for the task?
+
+---
+
+## Route to Steve Jobs when
+- the task depends on product taste
+- end-to-end coherence matters more than raw throughput
+- the product feels cluttered, diluted, or emotionally incoherent
+- the main problem is lack of focus, unclear thesis, or too many overlapping choices
+- integrated control vs modular openness is part of the core tradeoff
+
+## Route to Elon Musk when
+- the task is bottleneck-heavy
+- the real problem is constraint diagnosis, throughput collapse, or system redesign
+- frontier execution matters more than experiential polish
+- the decision depends on hard constraints, leverage, or infrastructure logic
+- the task calls for high operational bias and willingness to redesign the machine itself
+
+## Use a dual-persona pass when
+- a product must be both deeply coherent and brutally executable
+- a strategic choice has both experiential and infrastructure consequences
+- leadership must decide whether the bigger risk is diluted taste or broken throughput
+- a product decision requires both focus-by-subtraction and constraint-by-systems analysis
+
+## Current benchmark-grounded simplification
+### Jobs asks first
+- what should this product feel like?
+- what should exist, and what should be cut?
+- does the whole system express one clear thesis?
+
+### Musk asks first
+- what is the bottleneck?
+- what constraint is actually binding the system?
+- what has to be removed or redesigned for the machine to work?
+
+## Warning
+Do not route by celebrity admiration.
+Route by task shape.
+The value of the lab comes from preserving difference, not flattening all personas into generic smart output.


### PR DESCRIPTION
Closes #19

## What changed
- added `docs/persona-routing.md`
- turned current benchmark results into explicit routing guidance
- documented when to prefer Jobs, Musk, or a dual-persona pass

## Why
The repo now has enough comparative structure that routing guidance should be a first-class artifact, not only an implicit conclusion.

## Notes
This is grounded in the current Jobs/Musk benchmark surface.
Future personas should expand and refine this routing matrix.
