### PR TITLE
test: run Charlie Munger radar score v1

### DIFF
--- a/benchmarks/results/charlie-munger/radar-score-v1.md
+++ b/benchmarks/results/charlie-munger/radar-score-v1.md
@@ -1,0 +1,52 @@
+# Charlie Munger Radar Score v1
+
+## Scores
+- First-principles reasoning: 7
+- Systems / bottleneck thinking: 5
+- Product taste / aesthetic judgment: 3
+- Strategic focus: 8
+- Risk filtering: 10
+- Long-horizon vision: 8
+- Teaching / explanation clarity: 8
+- Human / emotional sensitivity: 6
+- Operational execution bias: 4
+- Investor-style judgment: 10
+
+## Justification summary
+Charlie Munger's current first-pass persona is strongest where judgment quality, error avoidance, incentives, and long-duration decision discipline matter.
+It is not primarily an execution-intensity or product-taste persona.
+That asymmetry is a feature, not a weakness, because the benchmark lab depends on preserving sharply differentiated cognition profiles.
+
+## Dimension notes
+### First-principles reasoning - 7
+Munger uses inversion and multi-model reasoning well, but his center of gravity is less engineering-first than Musk.
+
+### Systems / bottleneck thinking - 5
+He can reason about systems through incentives and failure patterns, but not with the same throughput-constraint emphasis as Musk.
+
+### Product taste / aesthetic judgment - 3
+This is not the natural home of the Munger persona.
+Jobs clearly dominates here.
+
+### Strategic focus - 8
+He is strong at saying no, filtering weak options, and concentrating on durable quality.
+
+### Risk filtering - 10
+This is the clearest high-score dimension.
+The current persona strongly centers avoidable stupidity, incentives, and unforced-error prevention.
+
+### Long-horizon vision - 8
+Munger is durable and compounding-oriented, though less world-rebuilding than Musk.
+
+### Teaching / explanation clarity - 8
+His style naturally compresses toward plain-spoken judgment principles and memorable clarity.
+
+### Human / emotional sensitivity - 6
+He understands human misjudgment and incentives well, but not primarily through empathic or relational sensitivity.
+
+### Operational execution bias - 4
+Munger is relatively weak here compared with Musk.
+He is more filter-first than action-intensity-first.
+
+### Investor-style judgment - 10
+This is a defining strength of the persona and should remain one of its signature differentiators.


### PR DESCRIPTION
Closes #25

## What changed
- added Charlie Munger radar score v1
- scored all benchmark dimensions
- documented why the current first-pass persona earns each score

## Why
Charlie Munger has now reached a benchmarkable first-pass state and should enter the same scoring system as Musk and Jobs.

## Notes
A next step could deepen this into a more formal detailed scoring sheet, then move into three-persona comparative benchmarking.
