### PR TITLE
test: run three-persona comparative benchmark

### DIFF
--- a/benchmarks/results/jobs-musk-munger-comparative-benchmark-v1.md
+++ b/benchmarks/results/jobs-musk-munger-comparative-benchmark-v1.md
@@ -1,0 +1,75 @@
+# Jobs vs Musk vs Munger Comparative Benchmark v1
+
+## Purpose
+This benchmark compares three reasoning-constraint personas across shared task shapes.
+The goal is not to crown a universal winner.
+It is to preserve useful differences so routing can become sharper.
+
+---
+
+## Shared question class 1 - product direction is muddy
+### Jobs
+Would likely compress toward taste, coherence, and subtraction.
+Primary move: remove the non-essential and clarify the product thesis.
+
+### Musk
+Would likely search for the execution or systems bottleneck causing product drift.
+Primary move: identify the constraint preventing product quality from emerging.
+
+### Munger
+Would likely inspect incentives, judgment errors, and organizational stupidity.
+Primary move: ask what incentives are rewarding muddiness and what bad decisions keep recurring.
+
+## Shared question class 2 - strategy under uncertainty
+### Jobs
+Would likely choose the path that preserves coherence and strong identity.
+
+### Musk
+Would likely choose the path with the highest leverage against the binding constraint.
+
+### Munger
+Would likely choose the path with the best judgment quality, lowest avoidable downside, and strongest long-term asymmetry.
+
+## Shared question class 3 - leadership failure
+### Jobs
+Reads failure as dilution, weak standards, and loss of taste control.
+
+### Musk
+Reads failure as bottleneck tolerance, low urgency, and broken system design.
+
+### Munger
+Reads failure as incentives gone wrong, unfiltered stupidity, and predictable misjudgment.
+
+## Shared question class 4 - when to use each persona
+### Use Jobs when
+- product coherence is collapsing
+- taste and clarity are the main missing variables
+- the challenge is deciding what to remove
+
+### Use Musk when
+- execution is blocked by a hard constraint
+- the system needs redesign
+- throughput and leverage matter most
+
+### Use Munger when
+- the real danger is bad judgment
+- incentives are distorted
+- the system is making repeated avoidable mistakes
+
+---
+
+## Three-persona panel pattern
+A useful composition sequence is:
+1. Jobs defines what the product should be.
+2. Musk identifies what prevents the machine from delivering it.
+3. Munger filters the plan for incentive distortion, unforced error, and weak judgment.
+
+This sequence is valuable because each persona attacks a different failure mode.
+
+## Routing implication v2
+The three-persona surface is now more stable than the earlier dual-persona surface.
+- Jobs covers coherence
+- Musk covers constraints
+- Munger covers judgment
+
+That means the lab can now support not only single-persona routing, but also structured multi-persona composition.


### PR DESCRIPTION
Closes #27

## What changed
- added a three-persona comparative benchmark for Jobs, Musk, and Munger
- compared the three personas across shared task classes
- extracted routing implication v2 and a panel composition pattern

## Why
The benchmark surface is now mature enough for a three-way comparison and stronger routing guidance.

## Notes
A next step could formalize this into a dedicated routing matrix or panel-orchestration guide.
