### PR TITLE
docs: formalize persona routing matrix and panel orchestration

### DIFF
--- a/docs/panel-orchestration.md
+++ b/docs/panel-orchestration.md
@@ -1,0 +1,35 @@
+# Panel Orchestration Guide v1
+
+## Purpose
+This guide explains how multiple personas should be composed.
+The point is not to average three voices together.
+The point is to sequence different cognition profiles against different failure modes.
+
+## Default three-persona sequence
+1. Steve Jobs defines what the product or outcome should be.
+2. Elon Musk identifies the bottleneck preventing delivery.
+3. Charlie Munger checks for incentive distortion, weak judgment, and avoidable error.
+
+## Why this order works
+- Jobs creates thesis clarity
+- Musk stress-tests execution reality
+- Munger removes bad judgment and structural stupidity
+
+## Conflict resolution
+### If Jobs and Musk conflict
+Ask whether the true limiting factor is coherence or throughput.
+
+### If Musk and Munger conflict
+Ask whether the more urgent risk is physical/system constraint or judgment/incentive failure.
+
+### If Jobs and Munger conflict
+Ask whether the bigger failure mode is diluted product quality or bad decision hygiene.
+
+## Synthesis rule
+The final synthesis should preserve difference before compressing to one recommendation.
+Do not flatten all personas into generic smart-sounding consensus too early.
+
+## Anti-patterns
+- do not use all three personas when one would do
+- do not confuse persona composition with roleplay
+- do not let the strongest rhetorical style dominate by charisma alone

--- a/docs/persona-routing-matrix.md
+++ b/docs/persona-routing-matrix.md
@@ -1,0 +1,40 @@
+# Persona Routing Matrix v1
+
+## Purpose
+This document turns benchmark conclusions into explicit routing rules.
+A persona should be chosen by task shape, not by admiration or tone preference.
+
+## Single-persona routing
+### Route to Steve Jobs when
+- the main problem is product coherence
+- the system feels cluttered or diluted
+- subtraction and sharp focus matter most
+
+### Route to Elon Musk when
+- the main problem is a bottleneck or hard constraint
+- throughput is broken
+- the machine itself needs redesign
+
+### Route to Charlie Munger when
+- the main problem is poor judgment
+- incentives are distorted
+- repeated avoidable mistakes are accumulating
+
+## Dual-persona routing
+### Jobs + Musk
+Use when a product needs both coherence and execution redesign.
+
+### Jobs + Munger
+Use when product direction is muddy and leadership judgment is unreliable.
+
+### Musk + Munger
+Use when a hard system problem is entangled with incentive distortion or repeated operational stupidity.
+
+## Three-persona routing
+Use Jobs + Musk + Munger when the task spans:
+- product coherence
+- system constraint / execution
+- judgment quality / incentive risk
+
+This is the most complete panel, but should not be the default for every task.
+Complexity should be earned by task shape.


### PR DESCRIPTION
Closes #29

## What changed
- added `docs/persona-routing-matrix.md`
- added `docs/panel-orchestration.md`
- formalized single, dual, and three-persona composition guidance

## Why
The lab now has enough benchmark evidence to turn routing and panel composition into explicit method rather than implicit conclusion.

## Notes
A next step could connect this method to runtime invocation protocol or live bakeoff testing.
