### PR TITLE
docs: add invocation prompt contract and examples

### DIFF
--- a/docs/prompt-contract.md
+++ b/docs/prompt-contract.md
@@ -1,0 +1,20 @@
+# Prompt Contract v1
+
+## Purpose
+This contract defines how persona invocation should be expressed.
+It exists so routing and panel composition can be tested more consistently.
+
+## Required fields
+- task
+- selected_persona_mode (`single`, `dual`, `panel`)
+- selected_personas
+- expected_output_shape
+
+## Optional fields
+- conflict_axis
+- synthesis_required
+- benchmark_context
+
+## Contract rule
+A persona invocation should state why the selected mode fits the task shape.
+It should not select personas arbitrarily.

--- a/harness/invocation-examples.md
+++ b/harness/invocation-examples.md
@@ -1,0 +1,29 @@
+# Invocation Examples
+
+## Example 1 - single persona
+Task: A product feels cluttered and unfocused.
+Mode: single
+Selected personas: Steve Jobs
+Expected output shape: identify what should be removed and restate the product thesis.
+
+## Example 2 - dual persona
+Task: A hardware/software product has both weak coherence and manufacturing bottlenecks.
+Mode: dual
+Selected personas: Steve Jobs, Elon Musk
+Expected output shape: one section on product coherence, one section on execution constraint, then synthesis.
+
+## Example 3 - dual persona
+Task: A fast-growing company is making poor leadership decisions under distorted incentives.
+Mode: dual
+Selected personas: Elon Musk, Charlie Munger
+Expected output shape: one section on bottlenecks, one section on incentives/judgment risk, then synthesis.
+
+## Example 4 - three-persona panel
+Task: A major product/platform decision affects UX coherence, operating constraints, and long-term organizational quality.
+Mode: panel
+Selected personas: Steve Jobs, Elon Musk, Charlie Munger
+Expected output shape:
+1. Jobs frames what the outcome should be.
+2. Musk identifies the binding constraint.
+3. Munger filters for avoidable stupidity and bad incentives.
+4. Final synthesis resolves the main conflict axis.


### PR DESCRIPTION
Closes #33

## What changed
- added `docs/prompt-contract.md`
- added `harness/invocation-examples.md`
- documented example invocations for single, dual, and three-persona usage

## Why
The invocation layer now has enough structure to benefit from explicit contract and fixture-style examples.

## Notes
A next step could turn these examples into executable tests or a lightweight harness script.
