### PR TITLE
feat: add lightweight invocation validator

### DIFF
--- a/harness/invocation-examples.json
+++ b/harness/invocation-examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "task": "A product feels cluttered and unfocused.",
+    "selected_persona_mode": "single",
+    "selected_personas": ["Steve Jobs"],
+    "expected_output_shape": "identify what should be removed and restate the product thesis"
+  },
+  {
+    "task": "A hardware/software product has both weak coherence and manufacturing bottlenecks.",
+    "selected_persona_mode": "dual",
+    "selected_personas": ["Steve Jobs", "Elon Musk"],
+    "expected_output_shape": "one section on product coherence, one section on execution constraint, then synthesis"
+  },
+  {
+    "task": "A major product/platform decision affects UX coherence, operating constraints, and long-term organizational quality.",
+    "selected_persona_mode": "panel",
+    "selected_personas": ["Steve Jobs", "Elon Musk", "Charlie Munger"],
+    "expected_output_shape": "Jobs frames the outcome, Musk identifies the constraint, Munger filters judgment risk, then synthesis",
+    "synthesis_required": true
+  }
+]

--- a/scripts/validate_invocation_contract.py
+++ b/scripts/validate_invocation_contract.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+REQUIRED = [
+    'task',
+    'selected_persona_mode',
+    'selected_personas',
+    'expected_output_shape',
+]
+VALID_MODES = {'single', 'dual', 'panel'}
+
+
+def validate_item(item, idx):
+    errors = []
+    for key in REQUIRED:
+        if key not in item:
+            errors.append(f'item {idx}: missing required field `{key}`')
+    mode = item.get('selected_persona_mode')
+    personas = item.get('selected_personas')
+    if mode is not None and mode not in VALID_MODES:
+        errors.append(f'item {idx}: invalid mode `{mode}`')
+    if personas is not None and not isinstance(personas, list):
+        errors.append(f'item {idx}: `selected_personas` must be a list')
+    if isinstance(personas, list):
+        expected_count = {'single': 1, 'dual': 2, 'panel': 3}.get(mode)
+        if expected_count and len(personas) != expected_count:
+            errors.append(
+                f'item {idx}: mode `{mode}` expects {expected_count} persona(s), got {len(personas)}'
+            )
+    return errors
+
+
+def main():
+    if len(sys.argv) != 2:
+        print('usage: validate_invocation_contract.py <json-file>')
+        return 2
+    path = Path(sys.argv[1])
+    data = json.loads(path.read_text())
+    if not isinstance(data, list):
+        print('top-level JSON must be a list')
+        return 2
+    errors = []
+    for i, item in enumerate(data, 1):
+        if not isinstance(item, dict):
+            errors.append(f'item {i}: must be an object')
+            continue
+        errors.extend(validate_item(item, i))
+    if errors:
+        print('INVALID')
+        for err in errors:
+            print(f'- {err}')
+        return 1
+    print(f'VALID: {len(data)} invocation example(s) passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #35

## What changed
- added `scripts/validate_invocation_contract.py`
- added JSON fixture examples for invocation validation
- validated single / dual / panel examples against the contract

## Why
The project now benefits from a minimal executable layer that checks whether invocation examples satisfy the prompt contract.

## Notes
A next step could expand this into richer runtime assembly or automated evaluation tests.
